### PR TITLE
ensure amount is a float when paying a bill or performing a topup

### DIFF
--- a/arcus/resources/bills.py
+++ b/arcus/resources/bills.py
@@ -51,6 +51,8 @@ class Bill(Resource):
         amount = amount or self.balance
         if not amount:
             raise ValueError('amount is not specified')
+        if not isinstance(amount, float):
+            raise TypeError('amount must be a float')
         data = dict(amount=amount, currency=self.balance_currency)
         transaction_dict = self._client.post(
             f'{self._endpoint}/{self.id}/pay', data)

--- a/arcus/resources/topups.py
+++ b/arcus/resources/topups.py
@@ -47,6 +47,8 @@ class Topup(Resource):
             currency: str = 'MXN',
             name_on_account: Optional[str] = None
     ):
+        if not isinstance(amount, float):
+            raise TypeError('amount must be a float')
         data = dict(biller_id=biller_id,
                     account_number=account_number,
                     amount=amount,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('README.md', 'r') as f:
 
 setuptools.setup(
     name='arcus',
-    version='0.2.9',
+    version='0.2.10',
     author='Cuenca',
     author_email='dev@cuenca.com',
     description='Arcus API Client',

--- a/tests/resources/cassettes/test_pay_with_int_amount.yaml
+++ b/tests/resources/cassettes/test_pay_with_int_amount.yaml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: '{"biller_id": 40, "account_number": "501000000007"}'
+    headers:
+      Accept: [application/vnd.regalii.v3.1+json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: ['APIAuth 88879c1b066dc9aea6201f27be2bbba9:r2sSQ2DED7RGXgH18/FnSjxmp+I=']
+      Connection: [keep-alive]
+      Content-Length: ['51']
+      Content-MD5: [PtZUYQ9bmh3ULNV0W7ZNdw==]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Jul 2019 00:43:43 GMT']
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://api.casiregalii.com/bills
+  response:
+    body: {string: '{"type":"bill","id":8390,"biller_id":40,"account_number":"501000000007","name_on_account":null,"due_date":null,"balance":549.0,"balance_currency":"MXN","balance_updated_at":"2019-07-19T00:43:43Z","error_code":null,"error_message":null,"status":"linked","migrated_at":null,"mfa_challenges":[]}'}
+    headers:
+      Cache-Control: ['max-age=0, private, must-revalidate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 19 Jul 2019 00:43:45 GMT']
+      ETag: [W/"d5887eda3a0381986e4683ee85b125e3"]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      X-Request-Id: [553e398b-867e-4a56-8922-0455ee8d026a]
+      X-Runtime: ['1.057190']
+    status: {code: 200, message: OK}
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/vnd.regalii.v3.1+json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: ['APIAuth 88879c1b066dc9aea6201f27be2bbba9:rJ0Vh6UleSWToAb8UYQPA+CPQ/8=']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-MD5: [mZFLkyvTelC5g8XnyQrpOw==]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Jul 2019 00:43:45 GMT']
+      User-Agent: [python-requests/2.21.0]
+    method: GET
+    uri: https://api.casiregalii.com/bills/8390
+  response:
+    body: {string: '{"type":"bill","id":8390,"biller_id":40,"account_number":"501000000007","name_on_account":null,"due_date":null,"balance":549.0,"balance_currency":"MXN","balance_updated_at":"2019-07-19T00:43:43Z","error_code":null,"error_message":null,"status":"linked","migrated_at":null,"mfa_challenges":[]}'}
+    headers:
+      Cache-Control: ['max-age=0, private, must-revalidate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Fri, 19 Jul 2019 00:43:45 GMT']
+      ETag: [W/"d5887eda3a0381986e4683ee85b125e3"]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Transfer-Encoding: [chunked]
+      X-Request-Id: [e6ca2bdd-2c7f-4cf8-84f7-97a5da000a0d]
+      X-Runtime: ['0.018602']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/resources/test_bills.py
+++ b/tests/resources/test_bills.py
@@ -37,6 +37,14 @@ def test_successful_payment(client):
 
 
 @pytest.mark.vcr
+def test_pay_with_int_amount(client):
+    bill = client.bills.create(40, '501000000007')
+    assert bill == client.bills.get(bill.id)
+    with pytest.raises(TypeError):
+        bill.pay(100)
+
+
+@pytest.mark.vcr
 def test_unexpected_error(client):
     with pytest.raises(exc.UnprocessableEntity) as excinfo:
         client.bills.create(6900, '1111362009')

--- a/tests/resources/test_topups.py
+++ b/tests/resources/test_topups.py
@@ -17,6 +17,15 @@ def test_topup(client):
 
 
 @pytest.mark.vcr
+def test_topup_with_int(client):
+    biller_id = 13599
+    account_number = '5599999999'
+    amount = 100
+    with pytest.raises(TypeError):
+        client.topups.create(biller_id, account_number, amount)
+
+
+@pytest.mark.vcr
 def test_topup_invalid_phone_number(client):
     biller_id = 13599
     account_number = '559999'


### PR DESCRIPTION
By checking that the amount is a float, it reduces the risk of the amount being passed in as centavos—instead of pesos.